### PR TITLE
make these defines work again

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -45,13 +45,13 @@ VRENDER ?= soft
 EXECUTABLE_DEFINED = 1
 
 # Dunno if MAME ever used this, but the retro OSD does for now
-TARGET ?= mame
-ifeq ($(TARGET), mess)
-	CORE_DEFINE := -DWANT_MESS
-else ifeq ($(TARGET), mame)
-	CORE_DEFINE := -DWANT_MAME
-else
+# TARGET ?= mame
+ifeq ($(TARGET), ume)
 	CORE_DEFINE := -DWANT_UME
+else ifeq ($(TARGET), mess)
+	CORE_DEFINE := -DWANT_MESS
+else
+	CORE_DEFINE := -DWANT_MAME
 endif
 
 # Ensure $(EMULATOR) has no suffixes

--- a/src/osd/retro/libretro_shared.h
+++ b/src/osd/retro/libretro_shared.h
@@ -65,14 +65,14 @@ extern float retro_aspect;
 extern float retro_fps;
 
 #if defined(WANT_MAME)
-static const char core[] = "mame";
+static const char core[] = "mame2014";
 #elif defined(WANT_MESS)
-static const char core[] = "mess";
+static const char core[] = "mess2014";
 #elif defined(WANT_UME)
-static const char core[] = "ume";
+static const char core[] = "ume2014";
 #else
 /* fallback */
-static const char core[] = "mame";
+static const char core[] = "mame2014";
 #endif
 
 /* libretro callbacks */
@@ -94,7 +94,7 @@ void process_mouse_state(void);
 #ifdef __cplusplus
 extern "C" {
 #endif
-   
+
 int mmain(int argc, const char *argv);
 
 #ifdef __cplusplus


### PR DESCRIPTION
so MESS and UME work again... dunno why @iKarith changed this
This line seems to be the problem:
   TARGET ?= mame

It caused the define to always be MAME
