### PR TITLE
Reimplement the disabled/missing hide options

### DIFF
--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -309,6 +309,7 @@ UINT32 ui_manager::set_handler(ui_callback callback, UINT32 param)
 #if 0
 #ifdef OSD_RETRO
 extern bool hide_nagscreen;
+extern bool hide_gameinfo;
 extern bool hide_warnings;
 #endif
 #endif
@@ -335,6 +336,8 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#ifdef OSD_RETRO
 	if(hide_nagscreen)
 		show_disclaimer = FALSE;
+	if(hide_gameinfo)
+		show_gameinfo = FALSE;
 	if(hide_warnings)
 		show_warnings = FALSE;
 	#endif

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -167,9 +167,9 @@ void retro_set_environment(retro_environment_t cb)
     { option_throttle, "Enable throttle; disabled|enabled" },
     { option_cheats, "Enable cheats; disabled|enabled" },
 //  { option_nobuffer, "Nobuffer patch; disabled|enabled" },
-//  { option_nag, "Hide nag screen; disabled|enabled" },
-//  { option_info, "Hide gameinfo screen; disabled|enabled" },
-//  { option_warnings, "Hide warnings screen; disabled|enabled" },
+    { option_nag, "Hide nag screen; disabled|enabled" },
+    { option_info, "Hide gameinfo screen; disabled|enabled" },
+    { option_warnings, "Hide warnings screen; disabled|enabled" },
     { option_renderer, "Alternate render method; disabled|enabled" },
 
     /* ONLY FOR MESS/UME */


### PR DESCRIPTION
Some of the code to hide the nag / warning / into screens that popup during MAME startup had either been disabled or was missing. This adds back in the disabled and fills in the missing bit.
