### PR TITLE
Remove legacy gameinfo switch and fix defines

### DIFF
--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -325,16 +325,18 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#endif
 
 	#ifdef OSD_RETRO
-		extern bool hide_nagscreen;
-		extern bool hide_infoscreen;
-		extern bool hide_warnings;
+		#ifdef hide_nagscreen
+			extern bool hide_nagscreen;
+			extern bool hide_infoscreen;
+			extern bool hide_warnings;
 
-		if(hide_nagscreen)
-			show_disclaimer = FALSE;
-		if(hide_infoscreen)
-			show_gameinfo = FALSE;
-		if(hide_warnings)
-			show_warnings = FALSE;
+			if(hide_nagscreen)
+				show_disclaimer = FALSE;
+			if(hide_infoscreen)
+				show_gameinfo = FALSE;
+			if(hide_warnings)
+				show_warnings = FALSE;
+		#endif
 	#endif
 
 	// loop over states

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -306,12 +306,6 @@ UINT32 ui_manager::set_handler(ui_callback callback, UINT32 param)
 //  various startup screens
 //-------------------------------------------------
 
-#ifdef OSD_RETRO
-	extern bool hide_nagscreen;
-	extern bool hide_infoscreen;
-	extern bool hide_warnings;
-#endif
-
 void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 {
 	const int maxstate = 4;
@@ -331,6 +325,10 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#endif
 
 	#ifdef OSD_RETRO
+		extern bool hide_nagscreen;
+		extern bool hide_infoscreen;
+		extern bool hide_warnings;
+
 		if(hide_nagscreen)
 			show_disclaimer = FALSE;
 		if(hide_infoscreen)

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -25,7 +25,7 @@
 #include "ui/sliders.h"
 #include "ui/viewgfx.h"
 #include "imagedev/cassette.h"
-#include "osd/retro/libretro_shared.h"
+#include "../osd/retro/libretro_shared.h"
 
 
 /***************************************************************************

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -325,12 +325,14 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#endif
 
 	#ifdef OSD_RETRO
-		if(hide_nagscreen)
-			show_disclaimer = FALSE;
-		if(hide_infoscreen)
-			show_gameinfo = FALSE;
-		if(hide_warnings)
-			show_warnings = FALSE;
+		#ifdef hide_infoscreen
+			if(hide_nagscreen)
+				show_disclaimer = FALSE;
+			if(hide_infoscreen)
+				show_gameinfo = FALSE;
+			if(hide_warnings)
+				show_warnings = FALSE;
+		#endif
 	#endif
 
 	// loop over states

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -325,18 +325,16 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#endif
 
 	#ifdef OSD_RETRO
-		#ifdef hide_nagscreen
-			extern bool hide_nagscreen;
-			extern bool hide_infoscreen;
-			extern bool hide_warnings;
+		extern bool hide_nagscreen;
+		extern bool hide_infoscreen;
+		extern bool hide_warnings;
 
-			if(hide_nagscreen)
-				show_disclaimer = FALSE;
-			if(hide_infoscreen)
-				show_gameinfo = FALSE;
-			if(hide_warnings)
-				show_warnings = FALSE;
-		#endif
+		if(hide_nagscreen)
+			show_disclaimer = FALSE;
+		if(hide_infoscreen)
+			show_gameinfo = FALSE;
+		if(hide_warnings)
+			show_warnings = FALSE;
 	#endif
 
 	// loop over states

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -25,6 +25,7 @@
 #include "ui/sliders.h"
 #include "ui/viewgfx.h"
 #include "imagedev/cassette.h"
+#include "osd/retro/libretro_shared.h"
 
 
 /***************************************************************************
@@ -325,10 +326,6 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#endif
 
 	#ifdef OSD_RETRO
-		extern bool hide_nagscreen;
-		extern bool hide_infoscreen;
-		extern bool hide_warnings;
-
 		if(hide_nagscreen)
 			show_disclaimer = FALSE;
 		if(hide_infoscreen)

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -325,11 +325,11 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#endif
 
 	#ifdef OSD_RETRO
-		extern bool hide_nagscreen;
-		extern bool hide_infoscreen;
-		extern bool hide_warnings;
-
 		#ifdef hide_nagscreen
+			extern bool hide_nagscreen;
+			extern bool hide_infoscreen;
+			extern bool hide_warnings;
+
 			if(hide_nagscreen)
 				show_disclaimer = FALSE;
 			if(hide_infoscreen)

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -325,6 +325,10 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#endif
 
 	#ifdef OSD_RETRO
+		extern bool hide_nagscreen;
+		extern bool hide_infoscreen;
+		extern bool hide_warnings;
+	
 		if(hide_nagscreen)
 			show_disclaimer = FALSE;
 		if(hide_infoscreen)

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -328,13 +328,15 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 		extern bool hide_nagscreen;
 		extern bool hide_infoscreen;
 		extern bool hide_warnings;
-	
-		if(hide_nagscreen)
-			show_disclaimer = FALSE;
-		if(hide_infoscreen)
-			show_gameinfo = FALSE;
-		if(hide_warnings)
-			show_warnings = FALSE;
+
+		#ifdef hide_nagscreen
+			if(hide_nagscreen)
+				show_disclaimer = FALSE;
+			if(hide_infoscreen)
+				show_gameinfo = FALSE;
+			if(hide_warnings)
+				show_warnings = FALSE;
+		#endif
 	#endif
 
 	// loop over states

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -308,7 +308,7 @@ UINT32 ui_manager::set_handler(ui_callback callback, UINT32 param)
 
 #ifdef OSD_RETRO
 	extern bool hide_nagscreen;
-	extern bool hide_gameinfo;
+	extern bool hide_infoscreen;
 	extern bool hide_warnings;
 #endif
 
@@ -333,7 +333,7 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#ifdef OSD_RETRO
 		if(hide_nagscreen)
 			show_disclaimer = FALSE;
-		if(hide_gameinfo)
+		if(hide_infoscreen)
 			show_gameinfo = FALSE;
 		if(hide_warnings)
 			show_warnings = FALSE;

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -325,14 +325,12 @@ void ui_manager::display_startup_screens(bool first_time, bool show_disclaimer)
 	#endif
 
 	#ifdef OSD_RETRO
-		#ifdef hide_infoscreen
-			if(hide_nagscreen)
-				show_disclaimer = FALSE;
-			if(hide_infoscreen)
-				show_gameinfo = FALSE;
-			if(hide_warnings)
-				show_warnings = FALSE;
-		#endif
+		if(hide_nagscreen)
+			show_disclaimer = FALSE;
+		if(hide_infoscreen)
+			show_gameinfo = FALSE;
+		if(hide_warnings)
+			show_warnings = FALSE;
 	#endif
 
 	// loop over states

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -25,7 +25,6 @@
 #include "ui/sliders.h"
 #include "ui/viewgfx.h"
 #include "imagedev/cassette.h"
-#include "../osd/retro/libretro_shared.h"
 
 
 /***************************************************************************

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -272,9 +272,9 @@ static void check_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "disabled") == 0)
-         hide_gameinfo = false;
+         hide_infoscreen = false;
       if (strcmp(var.value, "enabled") == 0)
-         hide_gameinfo = true;
+         hide_infoscreen = true;
    }
 
    var.key   = option_warnings;

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -258,13 +258,7 @@ static void check_variables(void)
    var.key   = option_nag;
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (strcmp(var.value, "disabled") == 0)
-         hide_nagscreen = false;
-      if (strcmp(var.value, "enabled") == 0)
-         hide_nagscreen = true;
-   }
+   hide_nagscreen = true;
 
    var.key   = option_info;
    var.value = NULL;

--- a/src/osd/retro/libretro_shared.h
+++ b/src/osd/retro/libretro_shared.h
@@ -41,6 +41,7 @@ extern bool softlist_auto;
 extern bool write_config_enable;
 extern bool read_config_enable;
 extern bool hide_nagscreen;
+extern bool hide_infoscreen;
 extern bool hide_warnings;
 extern bool throttle_enable;
 extern bool auto_save_enable;

--- a/src/osd/retro/libretro_shared.h
+++ b/src/osd/retro/libretro_shared.h
@@ -30,7 +30,6 @@ extern const char *retro_content_directory;
 extern int retro_pause;
 
 extern bool experimental_cmdline;
-extern bool hide_gameinfo;
 extern bool mouse_enable;
 extern bool cheats_enable;
 extern bool alternate_renderer;

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -59,10 +59,10 @@ int mame_reset = -1;
 
 /* core options */
 bool hide_nagscreen = false;
+bool hide_infoscreen = false;
 bool hide_warnings = false;
 bool nobuffer_enable = false;
 
-bool hide_gameinfo = false;
 bool mouse_enable = false;
 bool cheats_enable = false;
 bool alternate_renderer = false;
@@ -1047,11 +1047,6 @@ static void Set_Default_Option(void)
       Add_Option("-mouse");
    else
       Add_Option("-nomouse");
-
-   if(hide_gameinfo)
-      Add_Option("-skip_gameinfo");
-   else
-      Add_Option("-noskip_gameinfo");
 
    if(write_config_enable)
       Add_Option("-writeconfig");


### PR DESCRIPTION
Keep the names separate to avoid any confusion between the old and the new method.
