### PR TITLE
comment out RETRO_ENVIRONMENT_SHUTDOWN

### DIFF
--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -464,7 +464,7 @@ static void retro_wrap_emulator(void)
 
    retro_pause = -1;
 
-   environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, 0);
+//   environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, 0);
 
    /* Were done here. */
    co_switch(mainThread);


### PR DESCRIPTION
This seems to correct the issue where the core shuts the frontend down when you try to load another core/game. I didn't notice any problems after the change but it should probably be verified by others before merging.

Same thing as this PR for mame2010:
https://github.com/libretro/mame2010-libretro/pull/18
