### PR TITLE
Change button layout of some games

### DIFF
--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -1195,6 +1195,20 @@ static void Input_Binding(running_machine &machine)
 
    }
    else if (
+              (core_stricmp(machine.system().name, "dynwar") == 0) ||
+              (core_stricmp(machine.system().parent, "dynwar") == 0)
+           )
+   {
+	  /* Capcom CPS-1: Dynasty Wars */
+
+      Buttons_mapping[0]=RETROPAD_B;
+      Buttons_mapping[1]=RETROPAD_A;
+      Buttons_mapping[2]=RETROPAD_X;
+      Buttons_mapping[3]=RETROPAD_Y;
+      Buttons_mapping[4]=RETROPAD_L;
+      Buttons_mapping[5]=RETROPAD_R;
+   }
+   else if (
               (core_stricmp(machine.system().parent, "aof") == 0) ||
               (core_stricmp(machine.system().parent, "aof2") == 0) ||
               (core_stricmp(machine.system().parent, "aof3") == 0) ||

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -1209,6 +1209,20 @@ static void Input_Binding(running_machine &machine)
       Buttons_mapping[5]=RETROPAD_R;
    }
    else if (
+              (core_stricmp(machine.system().name, "ddsom") == 0) ||
+              (core_stricmp(machine.system().parent, "ddsom") == 0)
+           )
+   {
+	  /* Capcom CPS-2: Dungeons & Dragons: Shadow over Mystara (same layout of ddtod) */
+
+      Buttons_mapping[0]=RETROPAD_A;
+      Buttons_mapping[1]=RETROPAD_B;
+      Buttons_mapping[2]=RETROPAD_Y;
+      Buttons_mapping[3]=RETROPAD_X;
+      Buttons_mapping[4]=RETROPAD_L;
+      Buttons_mapping[5]=RETROPAD_R;
+   }
+   else if (
               (core_stricmp(machine.system().parent, "aof") == 0) ||
               (core_stricmp(machine.system().parent, "aof2") == 0) ||
               (core_stricmp(machine.system().parent, "aof3") == 0) ||

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -1345,7 +1345,7 @@ static void Input_Binding(running_machine &machine)
               (core_stricmp(machine.system().parent, "superchs") == 0)
            )
    {
-      /* Chase H.Q. and Super Chase - Criminal Termination */
+      /* Chase H.Q. / Super Chase - Criminal Termination */
 
       Buttons_mapping[0]=RETROPAD_A;
       Buttons_mapping[1]=RETROPAD_B;
@@ -1356,10 +1356,12 @@ static void Input_Binding(running_machine &machine)
    }
    else if (
               (core_stricmp(machine.system().name, "outrun") == 0) ||
-              (core_stricmp(machine.system().parent, "outrun") == 0)
+              (core_stricmp(machine.system().parent, "outrun") == 0) ||
+              (core_stricmp(machine.system().name, "turbo") == 0) ||
+              (core_stricmp(machine.system().parent, "turbo") == 0)
            )
    {
-      /* Out Run */
+      /* Out Run / Turbo */
 
       Buttons_mapping[0]=RETROPAD_A;
       Buttons_mapping[1]=RETROPAD_B;

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -1354,6 +1354,20 @@ static void Input_Binding(running_machine &machine)
       Buttons_mapping[4]=RETROPAD_L;
       Buttons_mapping[5]=RETROPAD_Y;
    }
+   else if (
+              (core_stricmp(machine.system().name, "outrun") == 0) ||
+              (core_stricmp(machine.system().parent, "outrun") == 0)
+           )
+   {
+      /* Out Run */
+
+      Buttons_mapping[0]=RETROPAD_A;
+      Buttons_mapping[1]=RETROPAD_B;
+      Buttons_mapping[2]=RETROPAD_R;
+      Buttons_mapping[3]=RETROPAD_Y;
+      Buttons_mapping[4]=RETROPAD_L;
+      Buttons_mapping[5]=RETROPAD_X;
+   }
 
 }
 

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -1199,7 +1199,7 @@ static void Input_Binding(running_machine &machine)
               (core_stricmp(machine.system().parent, "dynwar") == 0)
            )
    {
-	  /* Capcom CPS-1: Dynasty Wars */
+      /* Capcom CPS-1: Dynasty Wars */
 
       Buttons_mapping[0]=RETROPAD_B;
       Buttons_mapping[1]=RETROPAD_A;
@@ -1213,7 +1213,7 @@ static void Input_Binding(running_machine &machine)
               (core_stricmp(machine.system().parent, "ddsom") == 0)
            )
    {
-	  /* Capcom CPS-2: Dungeons & Dragons: Shadow over Mystara (same layout of ddtod) */
+      /* Capcom CPS-2: Dungeons & Dragons: Shadow over Mystara (same layout of ddtod) */
 
       Buttons_mapping[0]=RETROPAD_A;
       Buttons_mapping[1]=RETROPAD_B;

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -810,8 +810,8 @@ input_item_id PAD_DIR[4][4]=
    {ITEM_ID_8_PAD ,ITEM_ID_2_PAD   ,ITEM_ID_4_PAD   ,ITEM_ID_6_PAD }
 };
 
-//    Default : A ->B1 | B ->B2 | X ->B3 | Y ->B4 | L ->B5 | R ->B6
-int   Buttons_mapping[6]={RETROPAD_A,RETROPAD_B,RETROPAD_X,RETROPAD_Y,RETROPAD_L,RETROPAD_R};
+//    Default : A ->B1 | B ->B2 | X ->B3 | Y ->B4 | L ->B5 | R ->B6 | keyboard c ->B7 | keyboard v -> B8
+int   Buttons_mapping[8]={RETROPAD_A,RETROPAD_B,RETROPAD_X,RETROPAD_Y,RETROPAD_L,RETROPAD_R,RETROK_c,RETROK_v};
 
 static void Input_Binding(running_machine &machine);
 
@@ -989,6 +989,16 @@ static void initInput(running_machine &machine)
             &joystate[i].button[Buttons_mapping[4]],(input_item_id)(ITEM_ID_BUTTON1+4),generic_button_get_state );
       input_device_item_add_joy (i,Buttons_Name[Buttons_mapping[5]],\
             &joystate[i].button[Buttons_mapping[5]],(input_item_id)(ITEM_ID_BUTTON1+5),generic_button_get_state );
+      if (Buttons_mapping[6]!=RETROK_c)
+      {
+         input_device_item_add_joy (i,Buttons_Name[Buttons_mapping[6]],\
+               &joystate[i].button[Buttons_mapping[6]],(input_item_id)(ITEM_ID_BUTTON1+6),generic_button_get_state );
+      }
+      if (Buttons_mapping[7]!=RETROK_v)
+      {
+         input_device_item_add_joy (i,Buttons_Name[Buttons_mapping[7]],\
+               &joystate[i].button[Buttons_mapping[7]],(input_item_id)(ITEM_ID_BUTTON1+7),generic_button_get_state );
+      }
 
       sprintf(defname, "Pad%d", i);
       Pad_device[i] = machine.input().device_class(DEVICE_CLASS_KEYBOARD).add_device(defname);
@@ -1369,6 +1379,22 @@ static void Input_Binding(running_machine &machine)
       Buttons_mapping[3]=RETROPAD_Y;
       Buttons_mapping[4]=RETROPAD_L;
       Buttons_mapping[5]=RETROPAD_X;
+   }
+   else if (
+              (core_stricmp(machine.system().name, "vr") == 0) ||
+              (core_stricmp(machine.system().parent, "vr") == 0)
+           )
+   {
+      /* Virtua Racing */
+
+      Buttons_mapping[0]=RETROPAD_A;
+      Buttons_mapping[1]=RETROPAD_B;
+      Buttons_mapping[2]=RETROPAD_X;
+      Buttons_mapping[3]=RETROPAD_Y;
+      Buttons_mapping[4]=RETROPAD_PAD_DOWN;
+      Buttons_mapping[5]=RETROPAD_PAD_UP;
+      Buttons_mapping[6]=RETROPAD_L;
+      Buttons_mapping[7]=RETROPAD_R;
    }
 
 }

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -1338,6 +1338,22 @@ static void Input_Binding(running_machine &machine)
       Buttons_mapping[4]=RETROPAD_L;
       Buttons_mapping[5]=RETROPAD_R;
    }
+   else if (
+              (core_stricmp(machine.system().name, "chasehq") == 0) ||
+              (core_stricmp(machine.system().parent, "chasehq") == 0) ||
+              (core_stricmp(machine.system().name, "superchs") == 0) ||
+              (core_stricmp(machine.system().parent, "superchs") == 0)
+           )
+   {
+      /* Chase H.Q. and Super Chase - Criminal Termination */
+
+      Buttons_mapping[0]=RETROPAD_A;
+      Buttons_mapping[1]=RETROPAD_B;
+      Buttons_mapping[2]=RETROPAD_X;
+      Buttons_mapping[3]=RETROPAD_R;
+      Buttons_mapping[4]=RETROPAD_L;
+      Buttons_mapping[5]=RETROPAD_Y;
+   }
 
 }
 


### PR DESCRIPTION
Race games: Move shifter to L & R buttons

Change ddsom to make it like ddtod:

```
       X: magic
Y: magic select

       A: attack
B: jump
```

ddsom will also resemble Dynasty Wars, which has the magic/special move in the retropad X.