### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,11 @@ LDFLAGSEMULATOR =
 
 CCOMFLAGS  += -D__LIBRETRO__
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CCOMFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 $(info CFLAGS = $(CONLYFLAGS))
 $(info CPPFLAGS = $(CPPONLYFLAGS))
 

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -412,7 +412,10 @@ void retro_get_system_info(struct retro_system_info *info)
    info->library_name     = "MAME 2014";
 #endif
 
-   info->library_version  = "0.159";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = "0.159" GIT_VERSION;
    info->valid_extensions = "zip|chd|7z";
    info->need_fullpath    = true;
    info->block_extract    = true;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.