### PR TITLE
fix unintuitive default mame->retropad mapping

### DIFF
--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -1024,10 +1024,10 @@ static void Input_Binding(running_machine &machine)
    fprintf(stderr, "YEAR: %s\n", machine.system().year);
    fprintf(stderr, "MANUFACTURER: %s\n", machine.system().manufacturer);
 
-   Buttons_mapping[0]=RETROPAD_A;
+   Buttons_mapping[0]=RETROPAD_Y;
    Buttons_mapping[1]=RETROPAD_B;
-   Buttons_mapping[2]=RETROPAD_X;
-   Buttons_mapping[3]=RETROPAD_Y;
+   Buttons_mapping[2]=RETROPAD_A;
+   Buttons_mapping[3]=RETROPAD_X;
    Buttons_mapping[4]=RETROPAD_L;
    Buttons_mapping[5]=RETROPAD_R;
 


### PR DESCRIPTION
@shakkalakka has prepared extensive notes on the issue of the unintuitive/difficult to use default input mapping of this core: https://forums.libretro.com/t/default-input-mapping-for-mame2014-and-newer-is-wrong/11281

I'm submitting this PR on behalf of shakkalakka because they are concerned about their language barrier.

Many of the popular games already have coded independent defaults farther down in the source. In other words, this default does not change how every game is handled.

One way to evaluate the change would be to try to come up with any prominent examples where this would not be more intuitive.