### PR TITLE
Makefile: The BUILD variable can break builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -802,9 +802,9 @@ CDEFS = $(DEFS)
 # primary targets
 #-------------------------------------------------
 
-emulator: maketree $(BUILD) $(EMULATOR)
+emulator: maketree $(EMULATOR)
 
-buildtools: maketree $(BUILD)
+buildtools: maketree
 
 tools: maketree $(TOOLS)
 


### PR DESCRIPTION
The BUILD variable appears to be unused and can break the build if its exported in the environment which some build tools apparently do. So I think it should be safe to remove?

To reproduce this.
```
export BUILD=foo
make
```
Also see https://github.com/libretro/mame2010-libretro/pull/65