### PR TITLE
travis: Fix linux_x64 builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
   - cd ~/
   - git clone --depth=50 https://github.com/libretro/libretro-super
   - cd libretro-super/travis
-  - ./build-long.sh
+  - travis_wait 90 ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
   global:
     - COMPILER_NAME=gcc CXX=g++-7 CC=gcc-7
   matrix:
-    - PLATFORM=linux_x64 CORE=mame2014
-    - PLATFORM=linux_x64 CORE=mess2014
-    - PLATFORM=linux_x64 CORE=ume2014
+    - PLATFORM=linux_x64 CORE=mame2014 NAME=mame2014
+    - PLATFORM=linux_x64 CORE=mame2014 NAME=mess2014
+    - PLATFORM=linux_x64 CORE=mame2014 NAME=ume2014
 before_script:
   - pwd
   - mkdir -p ~/bin


### PR DESCRIPTION
I think this should fix travis for `linux_x64`, but of course please wait until travis actually successfully completes before merging.

The idea is that it should build all three mam2014 cores one at a time, this way if only one of them fails we can know which one. The buildbot currently builds mame2014 correctly for linux_x64 so it should not run into unforeseen issues.