### PR TITLE
update core name to MAME 2015

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
   global:
     - COMPILER_NAME=gcc CXX=g++-7 CC=gcc-7
   matrix:
-    - PLATFORM=linux_x64 CORE=mame2014 NAME=mame2014
-    - PLATFORM=linux_x64 CORE=mame2014 NAME=mess2014
-    - PLATFORM=linux_x64 CORE=mame2014 NAME=ume2014
+    - PLATFORM=linux_x64 CORE=mame2015 NAME=mame2015
+    - PLATFORM=linux_x64 CORE=mame2015 NAME=mess2015
+    - PLATFORM=linux_x64 CORE=mame2015 NAME=ume2015
 before_script:
   - pwd
   - mkdir -p ~/bin

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ARFLAGS = -cr
 
 ifeq ($(TARGET),)
    TARGET = mame
-   TARGET_NAME = mame2014
+   TARGET_NAME = mame2015
 endif
 
 EXE =
@@ -56,13 +56,13 @@ CORE_DIR := .
 
 ifeq ($(TARGET), mess)
    CORE_DEFINE := -DWANT_MESS
-   TARGET_NAME = mess2014
+   TARGET_NAME = mess2015
 else ifeq ($(TARGET), mame)
    CORE_DEFINE := -DWANT_MAME
-   TARGET_NAME = mame2014
+   TARGET_NAME = mame2015
 else
    CORE_DEFINE := -DWANT_UME
-   TARGET_NAME = ume2014
+   TARGET_NAME = ume2015
 endif
 $(info COREDEF = $(CORE_DEFINE))
 

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -403,19 +403,19 @@ void retro_get_system_info(struct retro_system_info *info)
    memset(info, 0, sizeof(*info));
 
 #if defined(WANT_MAME)
-   info->library_name     = "MAME 2014";
+   info->library_name     = "MAME 2015";
 #elif defined(WANT_MESS)
-   info->library_name     = "MESS 2014";
+   info->library_name     = "MESS 2015";
 #elif defined(WANT_UME)
-   info->library_name     = "UME 2014";
+   info->library_name     = "UME 2015";
 #else
-   info->library_name     = "MAME 2014";
+   info->library_name     = "MAME 2015";
 #endif
 
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif
-   info->library_version  = "0.159" GIT_VERSION;
+   info->library_version  = "0.160" GIT_VERSION;
    info->valid_extensions = "chd|cmd|zip|7z";
    info->need_fullpath    = true;
    info->block_extract    = true;

--- a/src/osd/retro/libretro_shared.h
+++ b/src/osd/retro/libretro_shared.h
@@ -63,14 +63,14 @@ extern float retro_aspect;
 extern float retro_fps;
 
 #if defined(WANT_MAME)
-static const char core[] = "mame2014";
+static const char core[] = "mame2015";
 #elif defined(WANT_MESS)
-static const char core[] = "mess2014";
+static const char core[] = "mess2015";
 #elif defined(WANT_UME)
-static const char core[] = "ume2014";
+static const char core[] = "ume2015";
 #else
 /* fallback */
-static const char core[] = "mame2014";
+static const char core[] = "mame2015";
 #endif
 
 /* libretro callbacks */


### PR DESCRIPTION
This PR follows the merge of https://github.com/libretro/libretro-super/pull/940 which initiated the process. This patch also updates the names of MESS 2014 and UME 2014.

The PRs relevant to the name update are:
  * MAME 2014 repo: https://github.com/libretro/mame2014-libretro/pull/73
  * libretro-super repo: https://github.com/libretro/libretro-super/pull/942
  * libretro-database repo: ~~https://github.com/libretro/libretro-database/pull/787~~ Merged
  * retroarch-assets repo: https://github.com/libretro/retroarch-assets/pull/289