### PR TITLE
Silence clang warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ ifneq (,$(findstring unix,$(platform)))
    TARGETOS=linux
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=src/osd/retro/link.T -Wl,--no-undefined
-   CCOMFLAGS += $(fpic) -fsigned-char -finline  -fno-common -fno-builtin -fweb -frename-registers -falign-functions=16
-   PLATCFLAGS +=  -DALIGN_INTS -DALIGN_SHORTS -fstrict-aliasing -fno-merge-constants
+   CCOMFLAGS += $(fpic) -fsigned-char -finline  -fno-common -fno-builtin -falign-functions=16
+   PLATCFLAGS +=  -DALIGN_INTS -DALIGN_SHORTS -fstrict-aliasing
    ifeq ($(VRENDER),opengl)
       PLATCFLAGS += -DHAVE_OPENGL
       LIBS += -lGL

--- a/src/build/flags_gcc.mak
+++ b/src/build/flags_gcc.mak
@@ -19,3 +19,8 @@ endif
 ifeq ($(findstring arm,$(UNAME)),arm)
 	CCOMFLAGS += -Wno-cast-align
 endif
+
+ifneq (,$(findstring unix,$(platform)))
+	CCOMFLAGS += -fweb -frename-registers
+	PLATCFLAGS += -fno-merge-constants
+endif


### PR DESCRIPTION
Silences numerous trivial, but annoying warnings with `clang-8.0.0`. I moved these to a gcc specific file so they can still be used by gcc users.
```
clang-8: warning: optimization flag '-fweb' is not supported [-Wignored-optimization-argument]
clang-8: warning: optimization flag '-frename-registers' is not supported [-Wignored-optimization-argument]
clang-8: warning: optimization flag '-fno-merge-constants' is not supported [-Wignored-optimization-argument]
```