### PR TITLE
Save/load state support for mame2015 core

### DIFF
--- a/src/emu/fileio.c
+++ b/src/emu/fileio.c
@@ -917,7 +917,6 @@ retro_buffer_writer::~retro_buffer_writer()
 {
 }
 
-        // writing
 UINT32 retro_buffer_writer::write(const void *buffer, UINT32 length)
 {
 	char* buf = (char*)buffer;

--- a/src/emu/fileio.c
+++ b/src/emu/fileio.c
@@ -907,3 +907,35 @@ file_error emu_file::load__7zped_file()
 	m__7zfile = NULL;
 	return FILERR_NONE;
 }
+
+retro_buffer::retro_buffer()
+        : m_vector()
+{
+}
+
+//        virtual ~retro_buffer();
+retro_buffer::~retro_buffer()
+{
+        // close in the standard way
+        // close();
+}
+
+
+        // reading
+UINT32 retro_buffer::read(void *buffer, UINT32 length)
+{
+        return 0;
+}
+
+        // writing
+UINT32 retro_buffer::write(const void *buffer, UINT32 length)
+{
+	char* buf = (char*)buffer;
+        m_vector.insert(m_vector.end(), buf, buf + length);
+        return length;
+}
+
+size_t retro_buffer::size()
+{
+	return m_vector.size();
+}

--- a/src/emu/fileio.c
+++ b/src/emu/fileio.c
@@ -925,14 +925,40 @@ UINT32 retro_buffer_writer::write(const void *buffer, UINT32 length)
         return length;
 }
 
+char* retro_buffer_writer::data()
+{
+	return m_vector.data();
+}
+
 size_t retro_buffer_writer::size()
 {
 	return m_vector.size();
 }
 
+retro_buffer_reader::retro_buffer_reader(const void *data, UINT32 size)
+{
+	m_data = data;
+	m_size = size;
+}
+
 UINT32 retro_buffer_reader::read(void *buffer, UINT32 length)
 {
-        return 0;
+	UINT32 read;
+	if(m_size > length)
+	{
+		read = length;
+	}
+	else
+	{
+		read = m_size;
+	}
+	memcpy(buffer, m_data, read);
+	m_data += read;
+	m_size -= read;
+        return read;
+}
+retro_buffer_reader::~retro_buffer_reader()
+{
 }
 
 

--- a/src/emu/fileio.c
+++ b/src/emu/fileio.c
@@ -908,34 +908,32 @@ file_error emu_file::load__7zped_file()
 	return FILERR_NONE;
 }
 
-retro_buffer::retro_buffer()
+retro_buffer_writer::retro_buffer_writer()
         : m_vector()
 {
 }
 
-//        virtual ~retro_buffer();
-retro_buffer::~retro_buffer()
+retro_buffer_writer::~retro_buffer_writer()
 {
-        // close in the standard way
-        // close();
-}
-
-
-        // reading
-UINT32 retro_buffer::read(void *buffer, UINT32 length)
-{
-        return 0;
 }
 
         // writing
-UINT32 retro_buffer::write(const void *buffer, UINT32 length)
+UINT32 retro_buffer_writer::write(const void *buffer, UINT32 length)
 {
 	char* buf = (char*)buffer;
         m_vector.insert(m_vector.end(), buf, buf + length);
         return length;
 }
 
-size_t retro_buffer::size()
+size_t retro_buffer_writer::size()
 {
 	return m_vector.size();
 }
+
+UINT32 retro_buffer_reader::read(void *buffer, UINT32 length)
+{
+        return 0;
+}
+
+
+

--- a/src/emu/fileio.h
+++ b/src/emu/fileio.h
@@ -15,6 +15,7 @@
 
 #include "corefile.h"
 #include "hash.h"
+#include <vector>
 
 // some systems use macros for getc/putc rather than functions
 #ifdef getc
@@ -170,6 +171,33 @@ private:
 	bool            m_remove_on_close;              // flag: remove the file when closing
 	bool        m_restrict_to_mediapath;    // flag: restrict to paths inside the media-path
 };
+
+// simple memory buffer modelled to be similar to emu_file
+
+class retro_buffer
+{
+public:
+        // file open/creation
+        retro_buffer();
+        virtual ~retro_buffer();
+
+
+        // control
+        //int seek(INT64 offset, int whence);
+        //UINT64 tell();
+        //bool eof();
+        //UINT64 size();
+
+        // reading
+        UINT32 read(void *buffer, UINT32 length);
+
+        // writing
+        UINT32 write(const void *buffer, UINT32 length);
+	size_t size();
+private:
+        std::vector<char>     m_vector;  // the actual buffer
+};
+
 
 
 #endif  /* __FILEIO_H__ */

--- a/src/emu/fileio.h
+++ b/src/emu/fileio.h
@@ -172,7 +172,11 @@ private:
 	bool        m_restrict_to_mediapath;    // flag: restrict to paths inside the media-path
 };
 
-
+/*
+Generic class to write data into a buffer.
+Made along the lines of emu_file with a compatible write method.
+Use a std::vector to store data.
+*/
 class retro_buffer_writer
 {
 public:
@@ -187,6 +191,11 @@ private:
         std::vector<char>     m_vector;  // the actual buffer
 };
 
+
+/*
+Generic class to read data from a buffer. Made along
+the line of emu_file
+*/
 class retro_buffer_reader
 {
 public:

--- a/src/emu/fileio.h
+++ b/src/emu/fileio.h
@@ -172,30 +172,32 @@ private:
 	bool        m_restrict_to_mediapath;    // flag: restrict to paths inside the media-path
 };
 
-// simple memory buffer modelled to be similar to emu_file
 
-class retro_buffer
+class retro_buffer_writer
 {
 public:
-        // file open/creation
-        retro_buffer();
-        virtual ~retro_buffer();
-
-
-        // control
-        //int seek(INT64 offset, int whence);
-        //UINT64 tell();
-        //bool eof();
-        //UINT64 size();
-
-        // reading
-        UINT32 read(void *buffer, UINT32 length);
+        retro_buffer_writer();
+        virtual ~retro_buffer_writer();
 
         // writing
         UINT32 write(const void *buffer, UINT32 length);
 	size_t size();
 private:
         std::vector<char>     m_vector;  // the actual buffer
+};
+
+class retro_buffer_reader
+{
+public:
+        retro_buffer_reader(const void *data, UINT32 size);
+        virtual ~retro_buffer_reader();
+
+        // reading
+        UINT32 read(void *buffer, UINT32 length);
+
+private:
+        const void*	m_data;
+	UINT32		m_size;	
 };
 
 

--- a/src/emu/fileio.h
+++ b/src/emu/fileio.h
@@ -182,6 +182,7 @@ public:
         // writing
         UINT32 write(const void *buffer, UINT32 length);
 	size_t size();
+	char* data();
 private:
         std::vector<char>     m_vector;  // the actual buffer
 };

--- a/src/emu/mame.c
+++ b/src/emu/mame.c
@@ -340,11 +340,13 @@ void retro_finish(){
 	printf("retro_finish end\n");
 }
 
+/* Called by libretro to save the state on a buffer */
 void retro_save_state(retro_buffer_writer &buf)
 {
 	retro_global_machine->save().retro_write_file(buf);
 }
 
+/* Called by libretro to load a state from a buffer */
 bool retro_load_state(retro_buffer_reader &buf)
 {
 	

--- a/src/emu/mame.c
+++ b/src/emu/mame.c
@@ -340,6 +340,11 @@ void retro_finish(){
 	printf("retro_finish end\n");
 }
 
+void retro_save_state(retro_buffer &buf)
+{
+	retro_global_machine->save().retro_write_file(buf);
+}
+
 void retro_main_loop()
 {
 	retro_global_machine->retro_loop();

--- a/src/emu/mame.c
+++ b/src/emu/mame.c
@@ -345,6 +345,11 @@ void retro_save_state(retro_buffer_writer &buf)
 	retro_global_machine->save().retro_write_file(buf);
 }
 
+bool retro_load_state(retro_buffer_reader &buf)
+{
+	return retro_global_machine->save().retro_read_file(buf) == STATERR_NONE;
+}
+
 void retro_main_loop()
 {
 	retro_global_machine->retro_loop();

--- a/src/emu/mame.c
+++ b/src/emu/mame.c
@@ -340,7 +340,7 @@ void retro_finish(){
 	printf("retro_finish end\n");
 }
 
-void retro_save_state(retro_buffer &buf)
+void retro_save_state(retro_buffer_writer &buf)
 {
 	retro_global_machine->save().retro_write_file(buf);
 }

--- a/src/emu/mame.c
+++ b/src/emu/mame.c
@@ -347,7 +347,11 @@ void retro_save_state(retro_buffer_writer &buf)
 
 bool retro_load_state(retro_buffer_reader &buf)
 {
-	return retro_global_machine->save().retro_read_file(buf) == STATERR_NONE;
+	
+	save_error r = retro_global_machine->save().retro_read_file(buf);
+	if (r == STATERR_NONE ) return true;
+	printf("retro_load_state error: %d \n", r);
+	return false;
 }
 
 void retro_main_loop()

--- a/src/emu/save.c
+++ b/src/emu/save.c
@@ -54,7 +54,7 @@ enum
 //**************************************************************************
 //  INITIALIZATION
 //**************************************************************************
-
+	
 //-------------------------------------------------
 //  save_manager - constructor
 //-------------------------------------------------
@@ -270,6 +270,47 @@ save_error save_manager::read_file(emu_file &file)
 }
 
 //-------------------------------------------------
+//  retro_read_file - read the data from a buffer
+//-------------------------------------------------
+
+save_error save_manager::retro_read_file(retro_buffer_reader &file)
+{
+	// if we have illegal registrations, return an error
+	if (m_illegal_regs > 0)
+		return STATERR_ILLEGAL_REGISTRATIONS;
+
+	// read the header and turn on compression for the rest of the file
+	UINT8 header[HEADER_SIZE];
+	if (file.read(header, sizeof(header)) != sizeof(header))
+		return STATERR_READ_ERROR;
+
+	// verify the header and report an error if it doesn't match
+	UINT32 sig = signature();
+	if (validate_header(header, machine().system().name, sig, popmessage, "Error: ")  != STATERR_NONE)
+		return STATERR_INVALID_HEADER;
+
+	// determine whether or not to flip the data when done
+	bool flip = NATIVE_ENDIAN_VALUE_LE_BE((header[9] & SS_MSB_FIRST) != 0, (header[9] & SS_MSB_FIRST) == 0);
+
+	// read all the data, flipping if necessary
+	for (state_entry *entry = m_entry_list.first(); entry != NULL; entry = entry->next())
+	{
+		UINT32 totalsize = entry->m_typesize * entry->m_typecount;
+		if (file.read(entry->m_data, totalsize) != totalsize)
+			return STATERR_READ_ERROR;
+
+		// handle flipping
+		if (flip)
+			entry->flip_data();
+	}
+
+	// call the post-load functions
+	dispatch_postload();
+
+	return STATERR_NONE;
+}
+
+//-------------------------------------------------
 //  dispatch_presave - invoke all registered
 //  presave callbacks for updates
 //-------------------------------------------------
@@ -282,10 +323,10 @@ void save_manager::dispatch_presave()
 }
 
 //-------------------------------------------------
-//  write_file - writes the data to a file
+//  retro_write_file - writes the data to a buffer
 //-------------------------------------------------
 
-save_error save_manager::retro_write_file(retro_buffer &file)
+save_error save_manager::retro_write_file(retro_buffer_writer &file)
 {
 	// if we have illegal registrations, return an error
 	if (m_illegal_regs > 0)

--- a/src/emu/save.c
+++ b/src/emu/save.c
@@ -325,7 +325,6 @@ void save_manager::dispatch_presave()
 //-------------------------------------------------
 //  retro_write_file - writes the data to a buffer
 //-------------------------------------------------
-
 save_error save_manager::retro_write_file(retro_buffer_writer &file)
 {
 	// if we have illegal registrations, return an error

--- a/src/emu/save.h
+++ b/src/emu/save.h
@@ -172,6 +172,7 @@ public:
 
 	// file processing
 	static save_error check_file(running_machine &machine, emu_file &file, const char *gamename, void (CLIB_DECL *errormsg)(const char *fmt, ...));
+	save_error retro_write_file(retro_buffer &file);
 	save_error write_file(emu_file &file);
 	save_error read_file(emu_file &file);
 

--- a/src/emu/save.h
+++ b/src/emu/save.h
@@ -172,8 +172,9 @@ public:
 
 	// file processing
 	static save_error check_file(running_machine &machine, emu_file &file, const char *gamename, void (CLIB_DECL *errormsg)(const char *fmt, ...));
-	save_error retro_write_file(retro_buffer &file);
+	save_error retro_write_file(retro_buffer_writer &file);
 	save_error write_file(emu_file &file);
+	save_error retro_read_file(retro_buffer_reader &file);
 	save_error read_file(emu_file &file);
 
 private:

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -632,14 +632,14 @@ void retro_unload_game(void)
 /* Stubs */
 size_t retro_serialize_size(void) 
 { 
-	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE CALLED");
+	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE CALLED\n");
 	if(serialize_size == 0)
 	{
 		retro_buffer_writer saveBuffer;
 		retro_save_state(saveBuffer);
 		serialize_size  = saveBuffer.size()*2; // allocate twice the space to be sure
 	}
-	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE IS: %d",serialize_size);
+	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE IS: %d\n",serialize_size);
 
 	return serialize_size; 
 }
@@ -647,9 +647,10 @@ bool retro_serialize(void *data, size_t size)
 {
 	retro_buffer_writer saveBuffer;
 	retro_save_state(saveBuffer);
-	if(saveBuffer.size() > size) 
+	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE ACTUAL SIZE IS: %d\n",saveBuffer.size());
+	if( (saveBuffer.size() > size) || (size>serialize_size) ) 
 	{
-		log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE too big. Got %d expected: %d stored %d",saveBuffer.size(), size, serialize_size);
+		log_cb(RETRO_LOG_ERROR, "RETRO_SERIALIZE too big. Got %d buffer size: %d stored size: %d\n",saveBuffer.size(), size, serialize_size);
 		return false;
 	}
 	memcpy(data, saveBuffer.data(), saveBuffer.size()); 
@@ -657,9 +658,14 @@ bool retro_serialize(void *data, size_t size)
 }
 bool retro_unserialize(const void * data, size_t size) 
 { 
+	log_cb(RETRO_LOG_INFO, "RETRO_UNSERIALIZE. SIZE: %d\n",size);
 	retro_buffer_reader readBuffer(data, size);
-	return retro_load_state(readBuffer);
-//	return true; 
+	bool ret = retro_load_state(readBuffer);
+	if(!ret) {
+		log_cb(RETRO_LOG_ERROR, "RETRO_UNSERIALIZE. ERROR!\n");
+	}
+	return ret;
+
 }
 
 unsigned retro_get_region (void) { return RETRO_REGION_NTSC; }

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -27,6 +27,8 @@ int SHIFTON           = -1;
 int NEWGAME_FROM_OSD  = 0;
 char RPATH[512];
 
+int serialize_size = 0; // memorize serialize size
+
 static char option_mouse[50];
 static char option_cheats[50];
 static char option_nag[50];
@@ -516,6 +518,7 @@ void retro_reset (void)
 
 int RLOOP=1;
 extern void retro_main_loop();
+extern void retro_save_state(retro_buffer &buf);
 
 void retro_run (void)
 {
@@ -625,7 +628,17 @@ void retro_unload_game(void)
 }
 
 /* Stubs */
-size_t retro_serialize_size(void) { return 0; }
+size_t retro_serialize_size(void) 
+{ 
+	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE CALLED");
+	
+	retro_buffer saveBuffer;
+	retro_save_state(saveBuffer);
+	serialize_size  = saveBuffer.size();
+	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE IS: %d",serialize_size);
+
+	return 0; 
+}
 bool retro_serialize(void *data, size_t size) { return false; }
 bool retro_unserialize(const void * data, size_t size) { return false; }
 

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -405,13 +405,13 @@ void retro_get_system_info(struct retro_system_info *info)
    memset(info, 0, sizeof(*info));
 
 #if defined(WANT_MAME)
-   info->library_name     = "MAME 2015";
+   info->library_name     = "MAME 2015 msx";
 #elif defined(WANT_MESS)
-   info->library_name     = "MESS 2015";
+   info->library_name     = "MESS 2015 msx";
 #elif defined(WANT_UME)
-   info->library_name     = "UME 2015";
+   info->library_name     = "UME 2015 msx";
 #else
-   info->library_name     = "MAME 2015";
+   info->library_name     = "MAME 2015 msx";
 #endif
 
 #ifndef GIT_VERSION
@@ -518,7 +518,7 @@ void retro_reset (void)
 
 int RLOOP=1;
 extern void retro_main_loop();
-extern void retro_save_state(retro_buffer &buf);
+extern void retro_save_state(retro_buffer_writer &buf);
 
 void retro_run (void)
 {
@@ -540,6 +540,7 @@ void retro_run (void)
 
    if (NEWGAME_FROM_OSD == 1)
    {
+	serialize_size = 0; // reset stored serial size
       struct retro_system_av_info ninfo;
 
       retro_get_system_av_info(&ninfo);
@@ -623,6 +624,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
 void retro_unload_game(void)
 {
+   serialize_size = 0;
    if (retro_pause == 0)
       retro_pause = -1;
 }
@@ -631,15 +633,21 @@ void retro_unload_game(void)
 size_t retro_serialize_size(void) 
 { 
 	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE CALLED");
-	
-	retro_buffer saveBuffer;
-	retro_save_state(saveBuffer);
-	serialize_size  = saveBuffer.size();
+	if(serialize_size == 0)
+	{
+		retro_buffer_writer saveBuffer;
+		retro_save_state(saveBuffer);
+		serialize_size  = saveBuffer.size()*2; // allocate twice the space to be sure
+	}
 	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE IS: %d",serialize_size);
 
-	return 0; 
+	return serialize_size; 
 }
-bool retro_serialize(void *data, size_t size) { return false; }
+bool retro_serialize(void *data, size_t size) 
+{
+	
+	return false; 
+}
 bool retro_unserialize(const void * data, size_t size) { return false; }
 
 unsigned retro_get_region (void) { return RETRO_REGION_NTSC; }

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -14,6 +14,8 @@
 #include "libretro.h"
 #include "libretro_shared.h"
 
+#define SAVE_SIZE_MULTIPLIER 1.5
+
 /* forward decls / externs / prototypes */
 bool retro_load_ok    = false;
 int retro_pause       = 0;
@@ -637,9 +639,10 @@ size_t retro_serialize_size(void)
 	{
 		retro_buffer_writer saveBuffer;
 		retro_save_state(saveBuffer);
-		serialize_size  = saveBuffer.size()*2; // allocate twice the space to be sure
+		serialize_size  = saveBuffer.size() * SAVE_SIZE_MULTIPLIER;
+		log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE IS: %d, ALLOCATED: %d\n", saveBuffer.size(), serialize_size);
 	}
-	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE IS: %d, ALLOCATED: %d\n",serialize_size / 2, serialize_size);
+
 
 	return serialize_size; 
 }

--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -639,7 +639,7 @@ size_t retro_serialize_size(void)
 		retro_save_state(saveBuffer);
 		serialize_size  = saveBuffer.size()*2; // allocate twice the space to be sure
 	}
-	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE IS: %d\n",serialize_size);
+	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE IS: %d, ALLOCATED: %d\n",serialize_size / 2, serialize_size);
 
 	return serialize_size; 
 }
@@ -647,7 +647,7 @@ bool retro_serialize(void *data, size_t size)
 {
 	retro_buffer_writer saveBuffer;
 	retro_save_state(saveBuffer);
-	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE_SIZE ACTUAL SIZE IS: %d\n",saveBuffer.size());
+	log_cb(RETRO_LOG_INFO, "RETRO_SERIALIZE ACTUAL SIZE IS: %d\n",saveBuffer.size());
 	if( (saveBuffer.size() > size) || (size>serialize_size) ) 
 	{
 		log_cb(RETRO_LOG_ERROR, "RETRO_SERIALIZE too big. Got %d buffer size: %d stored size: %d\n",saveBuffer.size(), size, serialize_size);


### PR DESCRIPTION
Hi there, this code implements support for save state in libretro, implementing the retro_(un)serialize calls.
Saving and loading is basically the one originally present in mame, i just wrote the data on a buffer instead that to a file and routed it to libretro callbacks.
Tested on some dozen games both new and old and it seems to work fine.

I'm not an expert in c++ so probably something could be optimized or written better but should be ok for a start.

There are some comments explaining how it works but let me know if you have any question! 