### PR TITLE
Fix for IOS build

### DIFF
--- a/src/emu/fileio.c
+++ b/src/emu/fileio.c
@@ -952,7 +952,7 @@ UINT32 retro_buffer_reader::read(void *buffer, UINT32 length)
 		read = m_size;
 	}
 	memcpy(buffer, m_data, read);
-	m_data += read;
+	m_data = ((char*)m_data) + read;
 	m_size -= read;
         return read;
 }


### PR DESCRIPTION
This change fix compilation error for IOS as reported [here](https://github.com/libretro/mame2015-libretro/commit/8a8cc78da65e77231e9e3ec5de3cc03a624d7710).
@WeedyWeedSmoker reports that it compiles correctly now. 