### PR TITLE
Makefile: update for python3 and enable override on OBJDUMP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,8 +524,8 @@ endif
 # utilities
 MD = -mkdir$(EXE_EXT)
 RM = @rm -f
-OBJDUMP = @objdump
-PYTHON ?= @python2
+OBJDUMP ?= @objdump
+PYTHON ?= @python3
 
 #-------------------------------------------------
 # form the name of the executable


### PR DESCRIPTION
Closes #90 

python2 is no longer default in Ubuntu focal and given that Kodi Matrix is now Python3 - the build for the addon should be updated. Additionally enable OBJDUMP to be overwritten for LibreELEC build instead of a local patch.

https://github.com/LibreELEC/LibreELEC.tv/blob/eadb3ac84392431f832e61aa02a881f3af9155ac/packages/emulation/libretro-mame2015/patches/libretro-mame2015-100.01-cross-compile.patch#L37-L38 