### PR TITLE
Remove "U" flag from open() statements in CPU Opcode Generators

### DIFF
--- a/src/emu/cpu/arcompact/arcompact_make.py
+++ b/src/emu/cpu/arcompact/arcompact_make.py
@@ -351,85 +351,79 @@ def EmitGroup17(f,funcname, opname, opexecute):
 
 
 try:
-    f = open(sys.argv[1], "w")
+    with open(sys.argv[1], "w") as f:
+        EmitGroup04(f, "04_00", "ADD",  "UINT32 result = b + c;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_Handle_NZCV_ADD_Flags )
+
+        EmitGroup04(f, "04_02", "SUB",  "UINT32 result = b - c;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+
+        EmitGroup04(f, "04_04", "AND",  "UINT32 result = b & c;",                 "if (areg != LIMM_REG) { m_regs[areg] = result; }", "if (breg != LIMM_REG) { m_regs[breg] = result; }", 0,0, -1, EmitGroup04_Handle_NZ_Flags  )
+        EmitGroup04(f, "04_05", "OR",   "UINT32 result = b | c;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "04_06", "BIC",  "UINT32 result = b & (~c);",              "m_regs[areg] = result;", "m_regs[breg] = result;",  0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "04_07", "XOR",  "UINT32 result = b ^ c;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+
+        EmitGroup04(f, "04_0a", "MOV",  "UINT32 result = c;",                     "m_regs[breg] = result;", "m_regs[breg] = result;", 1,1, -1, EmitGroup04_Handle_NZ_Flags  ) # special case, result always goes to breg
+
+        EmitGroup04(f, "04_0e", "RSUB", "UINT32 result = c - b;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "04_0f", "BSET", "UINT32 result = b | (1 << (c & 0x1f));", "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+
+        EmitGroup04(f, "04_13", "BMSK", "UINT32 result = b & ((1<<(c+1))-1);",    "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+
+
+        EmitGroup04(f, "04_14", "ADD1", "UINT32 result = b + (c << 1);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "04_15", "ADD2", "UINT32 result = b + (c << 2);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "04_16", "ADD3", "UINT32 result = b + (c << 3);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "04_17", "SUB1", "UINT32 result = b - (c << 1);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "04_18", "SUB2", "UINT32 result = b - (c << 2);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "04_19", "SUB3", "UINT32 result = b - (c << 3);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+
+        EmitGroup04(f, "04_2a", "LR", "m_regs[breg] = READAUX(c);", "", "", 1,1, -1, EmitGroup04_no_Flags  ) # this can't be conditional (todo)
+        EmitGroup04(f, "04_2b", "SR", "WRITEAUX(c,b);", "", "", 1,0, -1, EmitGroup04_no_Flags  ) # this can't be conditional (todo)
+
+
+
+        EmitGroup04(f, "05_00", "ASL", "UINT32 result = b << (c&0x1f);", "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+        EmitGroup04(f, "05_01", "LSR", "UINT32 result = b >> (c&0x1f);", "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
+
+        # the 04_2f subgroup uses the same encoding, but the areg is already used as sub-opcode select, so any modes relying on areg bits for other reasons (sign, condition) (modes 10, 11m0, 11m1) are illegal.  the destination is also breg not areg
+        EmitGroup04(f, "04_2f_02", "LSR1", "UINT32 result = c >> 1;",                                                                                                                             "m_regs[breg] = result;","", 2,1, -1, EmitGroup04_Handle_NZC_LSR1_Flags  ) # no alt handler (invalid path)
+        EmitGroup04(f, "04_2f_03", "ROR", "int shift = 1; UINT32 mask = (1 << (shift)) - 1; mask <<= (32-shift); UINT32 result = ((c >> shift) & ~mask) | ((c << (32-shift)) & mask);",          "m_regs[breg] = result;","", 2,1, -1, EmitGroup04_Handle_NZC_LSR1_Flags  )
+
+
+        EmitGroup04(f, "04_2f_07", "EXTB", "UINT32 result = c & 0x000000ff;",  "m_regs[breg] = result;","", 2,1, -1, EmitGroup04_unsupported_Flags  ) # ^
+        EmitGroup04(f, "04_2f_08", "EXTW", "UINT32 result = c & 0x0000ffff;",  "m_regs[breg] = result;","", 2,1, -1, EmitGroup04_unsupported_Flags  ) # ^
+
+        # xxx_S  c, b, u3  format opcodes (note c is destination)
+        EmitGroup0d(f, "0d_00", "ADD_S", "UINT32 result = m_regs[breg] + u;",         "m_regs[creg] = result;" )
+        EmitGroup0d(f, "0d_01", "SUB_S", "UINT32 result = m_regs[breg] - u;",         "m_regs[creg] = result;" )
+        EmitGroup0d(f, "0d_02", "ASL_S", "UINT32 result = m_regs[breg] << u;",        "m_regs[creg] = result;" )
+
+        # xxx_S b <- b,c format opcodes  (or in some cases xxx_S b,c)
+        EmitGroup0f(f, "0f_02", "SUB_S", "UINT32 result = m_regs[breg] - m_regs[creg];",        "m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_04", "AND_S", "UINT32 result = m_regs[breg] & m_regs[creg];",        "m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_05", "OR_S",  "UINT32 result = m_regs[breg] | m_regs[creg];",        "m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_07", "XOR_S", "UINT32 result = m_regs[breg] ^ m_regs[creg];",        "m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_0f", "EXTB_S","UINT32 result = m_regs[creg] & 0x000000ff;",          "m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_10", "EXTW_S","UINT32 result = m_regs[creg] & 0x0000ffff;",          "m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_13", "NEG_S"," UINT32 result = 0 - m_regs[creg];",                   "m_regs[breg] = result;" )
+
+        EmitGroup0f(f, "0f_14", "ADD1_S"," UINT32 result = m_regs[breg] + (m_regs[creg] <<1);", "m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_15", "ADD2_S"," UINT32 result = m_regs[breg] + (m_regs[creg] <<2);", "m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_16", "ADD3_S"," UINT32 result = m_regs[breg] + (m_regs[creg] <<3);", "m_regs[breg] = result;" )
+
+        EmitGroup0f(f, "0f_19", "LSR_S", "UINT32 result = m_regs[breg] >> (m_regs[creg]&0x1f);","m_regs[breg] = result;" )
+        EmitGroup0f(f, "0f_1b", "ASL1_S","UINT32 result = m_regs[creg] << 1;",                  "m_regs[breg] = result;" )
+
+
+        #  xxx_S b, b, u5 format opcodes
+        EmitGroup17(f, "17_00", "ASL_S",  "m_regs[breg] = m_regs[breg] << (u&0x1f);" )
+        EmitGroup17(f, "17_01", "LSR_S",  "m_regs[breg] = m_regs[breg] >> (u&0x1f);" )
+        EmitGroup17(f, "17_02", "ASR_S",  "INT32 temp = (INT32)m_regs[breg]; m_regs[breg] = temp >> (u&0x1f); // treat it as a signed value, so sign extension occurs during shift" )
+        EmitGroup17(f, "17_03", "SUB_S",  "m_regs[breg] = m_regs[breg] - u;" )
+        EmitGroup17(f, "17_04", "BSET_S", "m_regs[breg] = m_regs[breg] | (1 << (u & 0x1f));" )
+
+        EmitGroup17(f, "17_06", "BMSK_S", "m_regs[breg] = m_regs[breg] | ((1 << (u + 1)) - 1);" )
+
 except Exception:
     err = sys.exc_info()[1]
     sys.stderr.write("cannot write file %s [%s]\n" % (sys.argv[1], err))
     sys.exit(1)
-
-
-EmitGroup04(f, "04_00", "ADD",  "UINT32 result = b + c;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_Handle_NZCV_ADD_Flags )
-
-EmitGroup04(f, "04_02", "SUB",  "UINT32 result = b - c;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-
-EmitGroup04(f, "04_04", "AND",  "UINT32 result = b & c;",                 "if (areg != LIMM_REG) { m_regs[areg] = result; }", "if (breg != LIMM_REG) { m_regs[breg] = result; }", 0,0, -1, EmitGroup04_Handle_NZ_Flags  )
-EmitGroup04(f, "04_05", "OR",   "UINT32 result = b | c;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "04_06", "BIC",  "UINT32 result = b & (~c);",              "m_regs[areg] = result;", "m_regs[breg] = result;",  0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "04_07", "XOR",  "UINT32 result = b ^ c;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-
-EmitGroup04(f, "04_0a", "MOV",  "UINT32 result = c;",                     "m_regs[breg] = result;", "m_regs[breg] = result;", 1,1, -1, EmitGroup04_Handle_NZ_Flags  ) # special case, result always goes to breg
-
-EmitGroup04(f, "04_0e", "RSUB", "UINT32 result = c - b;",                 "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "04_0f", "BSET", "UINT32 result = b | (1 << (c & 0x1f));", "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-
-EmitGroup04(f, "04_13", "BMSK", "UINT32 result = b & ((1<<(c+1))-1);",    "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-
-
-EmitGroup04(f, "04_14", "ADD1", "UINT32 result = b + (c << 1);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "04_15", "ADD2", "UINT32 result = b + (c << 2);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "04_16", "ADD3", "UINT32 result = b + (c << 3);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "04_17", "SUB1", "UINT32 result = b - (c << 1);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "04_18", "SUB2", "UINT32 result = b - (c << 2);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "04_19", "SUB3", "UINT32 result = b - (c << 3);",          "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-
-EmitGroup04(f, "04_2a", "LR", "m_regs[breg] = READAUX(c);", "", "", 1,1, -1, EmitGroup04_no_Flags  ) # this can't be conditional (todo)
-EmitGroup04(f, "04_2b", "SR", "WRITEAUX(c,b);", "", "", 1,0, -1, EmitGroup04_no_Flags  ) # this can't be conditional (todo)
-
-
-
-EmitGroup04(f, "05_00", "ASL", "UINT32 result = b << (c&0x1f);", "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-EmitGroup04(f, "05_01", "LSR", "UINT32 result = b >> (c&0x1f);", "m_regs[areg] = result;", "m_regs[breg] = result;", 0,0, -1, EmitGroup04_unsupported_Flags  )
-
-# the 04_2f subgroup uses the same encoding, but the areg is already used as sub-opcode select, so any modes relying on areg bits for other reasons (sign, condition) (modes 10, 11m0, 11m1) are illegal.  the destination is also breg not areg
-EmitGroup04(f, "04_2f_02", "LSR1", "UINT32 result = c >> 1;",                                                                                                                             "m_regs[breg] = result;","", 2,1, -1, EmitGroup04_Handle_NZC_LSR1_Flags  ) # no alt handler (invalid path)
-EmitGroup04(f, "04_2f_03", "ROR", "int shift = 1; UINT32 mask = (1 << (shift)) - 1; mask <<= (32-shift); UINT32 result = ((c >> shift) & ~mask) | ((c << (32-shift)) & mask);",          "m_regs[breg] = result;","", 2,1, -1, EmitGroup04_Handle_NZC_LSR1_Flags  )
-
-
-EmitGroup04(f, "04_2f_07", "EXTB", "UINT32 result = c & 0x000000ff;",  "m_regs[breg] = result;","", 2,1, -1, EmitGroup04_unsupported_Flags  ) # ^
-EmitGroup04(f, "04_2f_08", "EXTW", "UINT32 result = c & 0x0000ffff;",  "m_regs[breg] = result;","", 2,1, -1, EmitGroup04_unsupported_Flags  ) # ^
-
-# xxx_S  c, b, u3  format opcodes (note c is destination)
-EmitGroup0d(f, "0d_00", "ADD_S", "UINT32 result = m_regs[breg] + u;",         "m_regs[creg] = result;" )
-EmitGroup0d(f, "0d_01", "SUB_S", "UINT32 result = m_regs[breg] - u;",         "m_regs[creg] = result;" )
-EmitGroup0d(f, "0d_02", "ASL_S", "UINT32 result = m_regs[breg] << u;",        "m_regs[creg] = result;" )
-
-# xxx_S b <- b,c format opcodes  (or in some cases xxx_S b,c)
-EmitGroup0f(f, "0f_02", "SUB_S", "UINT32 result = m_regs[breg] - m_regs[creg];",        "m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_04", "AND_S", "UINT32 result = m_regs[breg] & m_regs[creg];",        "m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_05", "OR_S",  "UINT32 result = m_regs[breg] | m_regs[creg];",        "m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_07", "XOR_S", "UINT32 result = m_regs[breg] ^ m_regs[creg];",        "m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_0f", "EXTB_S","UINT32 result = m_regs[creg] & 0x000000ff;",          "m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_10", "EXTW_S","UINT32 result = m_regs[creg] & 0x0000ffff;",          "m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_13", "NEG_S"," UINT32 result = 0 - m_regs[creg];",                   "m_regs[breg] = result;" )
-
-EmitGroup0f(f, "0f_14", "ADD1_S"," UINT32 result = m_regs[breg] + (m_regs[creg] <<1);", "m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_15", "ADD2_S"," UINT32 result = m_regs[breg] + (m_regs[creg] <<2);", "m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_16", "ADD3_S"," UINT32 result = m_regs[breg] + (m_regs[creg] <<3);", "m_regs[breg] = result;" )
-
-EmitGroup0f(f, "0f_19", "LSR_S", "UINT32 result = m_regs[breg] >> (m_regs[creg]&0x1f);","m_regs[breg] = result;" )
-EmitGroup0f(f, "0f_1b", "ASL1_S","UINT32 result = m_regs[creg] << 1;",                  "m_regs[breg] = result;" )
-
-
-#  xxx_S b, b, u5 format opcodes
-EmitGroup17(f, "17_00", "ASL_S",  "m_regs[breg] = m_regs[breg] << (u&0x1f);" )
-EmitGroup17(f, "17_01", "LSR_S",  "m_regs[breg] = m_regs[breg] >> (u&0x1f);" )
-EmitGroup17(f, "17_02", "ASR_S",  "INT32 temp = (INT32)m_regs[breg]; m_regs[breg] = temp >> (u&0x1f); // treat it as a signed value, so sign extension occurs during shift" )
-EmitGroup17(f, "17_03", "SUB_S",  "m_regs[breg] = m_regs[breg] - u;" )
-EmitGroup17(f, "17_04", "BSET_S", "m_regs[breg] = m_regs[breg] | (1 << (u & 0x1f));" )
-
-EmitGroup17(f, "17_06", "BMSK_S", "m_regs[breg] = m_regs[breg] | ((1 << (u + 1)) - 1);" )
-
-
-
-
-

--- a/src/emu/cpu/m6502/m6502make.py
+++ b/src/emu/cpu/m6502/m6502make.py
@@ -16,22 +16,22 @@ def load_opcodes(fname):
     opcodes = []
     logging.info("load_opcodes: %s", fname)
     try:
-        f = open(fname, "rU")
+        with open(fname, "r") as f:
+            for line in f:
+                if line.startswith("#"): continue
+                line = line.rstrip()
+                if not line: continue
+                if line.startswith(" ") or line.startswith("\t"):
+                    # append instruction to last opcode
+                    opcodes[-1][1].append(line)
+                else:
+                    # add new opcode
+                    opcodes.append((line, []))
     except Exception:
         err = sys.exc_info()[1]
         logging.error("cannot read opcodes file %s [%s]", fname, err)
         sys.exit(1)
 
-    for line in f:
-        if line.startswith("#"): continue
-        line = line.rstrip()
-        if not line: continue
-        if line.startswith(" ") or line.startswith("\t"):
-            # append instruction to last opcode
-            opcodes[-1][1].append(line)
-        else:
-            # add new opcode
-            opcodes.append((line, []))
     return opcodes
 
 
@@ -39,17 +39,18 @@ def load_disp(fname):
     logging.info("load_disp: %s", fname)
     states = []
     try:
-        f = open(fname, "rU")
+        with open(fname, "r") as f:
+            for line in f:
+                if line.startswith("#"): continue
+                line = line.strip()
+                if not line: continue
+                tokens = line.split()
+                states += tokens
     except Exception:
         err = sys.exc_info()[1]
         logging.error("cannot read display file %s [%s]", fname, err)
         sys.exit(1)
-    for line in f:
-        if line.startswith("#"): continue
-        line = line.strip()
-        if not line: continue
-        tokens = line.split()
-        states += tokens
+
     return states
 
 def emit(f, text):
@@ -229,15 +230,14 @@ def save_tables(f, device, states):
 def save(fname, device, opcodes, states):
     logging.info("saving: %s", fname)
     try:
-        f = open(fname, "w")
+        with open(fname, "w") as f:
+            save_opcodes(f, device, opcodes)
+            emit(f, "\n")
+            save_tables(f, device, states)
     except Exception:
         err = sys.exc_info()[1]
         logging.error("cannot write file %s [%s]", fname, err)
         sys.exit(1)
-    save_opcodes(f,device, opcodes)
-    emit(f, "\n")
-    save_tables(f, device, states)
-    f.close()
 
 
 def main(argv):

--- a/src/emu/cpu/m6809/m6809make.py
+++ b/src/emu/cpu/m6809/m6809make.py
@@ -10,27 +10,25 @@ dispatch_to_states = { "MAIN" : 0 }
 states_to_dispatch = { 0 : "MAIN" }
 
 def load_file(fname, lines):
-	path = fname.rpartition('/')[0]
-	if path != "":
-		path += '/'
-	try:
-		f = open(fname, "rU")
-	except Exception:
-		err = sys.exc_info()[1]
-		sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
-		sys.exit(1)
-	
-	rawlines = re.split('(\n|; *\n?)', f.read())
-	count = 0
-	while count < len(rawlines)-1:
-		line = rawlines[count+0] + rawlines[count+1]
-		if line.startswith("#include"):
-			load_file(path + line.split('"')[1], lines)
-		else:
-			lines.append(line)
-		count += 2
-	
-	f.close()
+    path = fname.rpartition('/')[0]
+    if path != "":
+        path += '/'
+    try:
+        with open(fname, "r") as f:
+            rawlines = re.split('(\n|; *\n?)', f.read())
+            count = 0
+            while count < len(rawlines)-1:
+                line = rawlines[count+0] + rawlines[count+1]
+                if line.startswith("#include"):
+                    load_file(path + line.split('"')[1], lines)
+                else:
+                    lines.append(line)
+                count += 2
+    except Exception:
+        err = sys.exc_info()[1]
+        sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+        sys.exit(1)
+    
 
 # Get lines
 lines = []
@@ -38,82 +36,82 @@ load_file(sys.argv[1], lines)
 
 count = 0
 while count < len(lines):
-	# Retrieve this line
-	line = lines[count]
+    # Retrieve this line
+    line = lines[count]
 
-	# Retrieve the whitespace
-	whitespace = line[:len(line) - len(line.lstrip())]
+    # Retrieve the whitespace
+    whitespace = line[:len(line) - len(line.lstrip())]
 
-	# Check to see if the next line is a return
-	next_line_is_return = (count + 1 == len(lines)) or lines[count+1].strip() == "return;"
+    # Check to see if the next line is a return
+    next_line_is_return = (count + 1 == len(lines)) or lines[count+1].strip() == "return;"
 
-	# Check to see if the next line is a dispatch followed by return
-	next_line_is_dispatch_and_return = (count + 1 < len(lines)) and re.match('([A-Za-z0-9\t ]+\:)*\s*\%', lines[count+1]) and lines[count+2].strip() == "return;"
+    # Check to see if the next line is a dispatch followed by return
+    next_line_is_dispatch_and_return = (count + 1 < len(lines)) and re.match('([A-Za-z0-9\t ]+\:)*\s*\%', lines[count+1]) and lines[count+2].strip() == "return;"
 
-	if re.match('([A-Za-z0-9\t ]+\:)*\s*\%', line):
-		# This is a dispatch - find the '%'
-		percent_pos = line.find("%")
-		dispatch = line[percent_pos+1:].strip("\t\n; ")
+    if re.match('([A-Za-z0-9\t ]+\:)*\s*\%', line):
+        # This is a dispatch - find the '%'
+        percent_pos = line.find("%")
+        dispatch = line[percent_pos+1:].strip("\t\n; ")
 
-		# Do we have a label?
-		label = line[:percent_pos].strip()
-		if label != "":
-			text += whitespace + label + "\n"
-			whitespace += "\t"
-		
-		# Create the goto command
-		if dispatch[-1:] == "*":
-			goto_command = "if (is_register_register_op_16_bit()) goto %s16; else goto %s8;\n" %(dispatch[:-1], dispatch[:-1])
-		else:
-			goto_command = "goto %s;\n" % dispatch
+        # Do we have a label?
+        label = line[:percent_pos].strip()
+        if label != "":
+            text += whitespace + label + "\n"
+            whitespace += "\t"
+        
+        # Create the goto command
+        if dispatch[-1:] == "*":
+            goto_command = "if (is_register_register_op_16_bit()) goto %s16; else goto %s8;\n" %(dispatch[:-1], dispatch[:-1])
+        else:
+            goto_command = "goto %s;\n" % dispatch
 
-		# Are we right before a 'return'?
-		if next_line_is_return:
-			text += whitespace + goto_command
-			count += 1  # Skip the return
-		elif next_line_is_dispatch_and_return:
-			# We are followed by a dispatch/return combo; identify the next dispatch
-			percent_pos = lines[count+1].find("%")
-			next_dispatch = lines[count+1][percent_pos+1:].strip("\t\n; ")
+        # Are we right before a 'return'?
+        if next_line_is_return:
+            text += whitespace + goto_command
+            count += 1  # Skip the return
+        elif next_line_is_dispatch_and_return:
+            # We are followed by a dispatch/return combo; identify the next dispatch
+            percent_pos = lines[count+1].find("%")
+            next_dispatch = lines[count+1][percent_pos+1:].strip("\t\n; ")
 
-			# If there is no state number associated with the next dispatch, make one
-			if next_dispatch not in dispatch_to_states:
-				dispatch_to_states[next_dispatch] = state
-				states_to_dispatch[state] = next_dispatch
-				state += 1
+            # If there is no state number associated with the next dispatch, make one
+            if next_dispatch not in dispatch_to_states:
+                dispatch_to_states[next_dispatch] = state
+                states_to_dispatch[state] = next_dispatch
+                state += 1
 
-			text += whitespace + "push_state(%s);\t// %s\n" % (dispatch_to_states[next_dispatch], next_dispatch)
-			text += whitespace + goto_command
-			count += 2  # Skip the dispatch/return
+            text += whitespace + "push_state(%s);\t// %s\n" % (dispatch_to_states[next_dispatch], next_dispatch)
+            text += whitespace + goto_command
+            count += 2  # Skip the dispatch/return
 
-		else:
-			# Normal dispatch
-			text += whitespace + "push_state(%s);\n" % state
-			text += whitespace + goto_command
-			text += "state_%s:\n" % state
-			state += 1
-	else:
-		# "Normal" code
-		# Is there an '@' here?
-		check_icount = line.lstrip().startswith("@")
-		if check_icount:
-			line = line.replace("@", "", 1)
+        else:
+            # Normal dispatch
+            text += whitespace + "push_state(%s);\n" % state
+            text += whitespace + goto_command
+            text += "state_%s:\n" % state
+            state += 1
+    else:
+        # "Normal" code
+        # Is there an '@' here?
+        check_icount = line.lstrip().startswith("@")
+        if check_icount:
+            line = line.replace("@", "", 1)
 
-		# Output the line
-		text += line
+        # Output the line
+        text += line
 
-		# If we have to decrement the icount, output more info
-		if check_icount and not next_line_is_return:
-			text += whitespace + "if (UNEXPECTED(m_icount <= 0)) { push_state(%s); return; }\n" % state
-			text += "state_%s:\n" % state
-			state += 1
+        # If we have to decrement the icount, output more info
+        if check_icount and not next_line_is_return:
+            text += whitespace + "if (UNEXPECTED(m_icount <= 0)) { push_state(%s); return; }\n" % state
+            text += "state_%s:\n" % state
+            state += 1
 
-	# Advance to next line
-	count += 1
+    # Advance to next line
+    count += 1
 
 # Output the case labels
 for i in range(0, state):
-	print("\tcase %d:	goto %s;" % (i, states_to_dispatch.get(i, "state_%d" % i)))
+    print("\tcase %d:   goto %s;" % (i, states_to_dispatch.get(i, "state_%d" % i)))
 
 # Output a default case
 print("\tdefault:")

--- a/src/emu/cpu/tms57002/tmsmake.py
+++ b/src/emu/cpu/tms57002/tmsmake.py
@@ -326,18 +326,19 @@ def ins_cmp_dasm(a, b):
 def LoadLst(filename):
     instructions = []
     ins = None
-    for n, line in enumerate(open(filename, "rU")):
-        line = line.rstrip()
-        if not line and ins:
-            # new lines separate intructions
-            ins.Finalize()
-            ins = None
-        elif line[0] in [" ", "\t"]:
-            assert ins
-            ins.AddInfo(line)
-        else:
-            ins = Instruction(line)
-            instructions.append(ins)
+    with open(filename, "r") as f:
+        for n, line in enumerate(f):
+            line = line.rstrip()
+            if not line and ins:
+                # new lines separate intructions
+                ins.Finalize()
+                ins = None
+            elif line[0] in [" ", "\t"]:
+                assert ins
+                ins.AddInfo(line)
+            else:
+                ins = Instruction(line)
+                instructions.append(ins)
     if ins:
         ins.Finalize()
     return instructions
@@ -416,12 +417,12 @@ def EmitCintrp(f, ins_list):
 
 ins_list = LoadLst(sys.argv[1])
 try:
-    f = open(sys.argv[2], "w")
+    with open(sys.argv[2], "w") as f:
+        EmitDasm(f, ins_list)
+        EmitCdec(f, ins_list)
+        EmitCintrp(f, ins_list)
 except Exception:
     err = sys.exc_info()[1]
     sys.stderr.write("cannot write file %s [%s]\n" % (sys.argv[2], err))
     sys.exit(1)
 
-EmitDasm(f, ins_list)
-EmitCdec(f, ins_list)
-EmitCintrp(f, ins_list)


### PR DESCRIPTION
The "U" flag has been removed from Python 3.11 and Universal Newlines are the default in Python 3 anyways.